### PR TITLE
Update TranscodingTask.php

### DIFF
--- a/src/Classes/TranscodingTask.php
+++ b/src/Classes/TranscodingTask.php
@@ -65,7 +65,7 @@ class TranscodingTask {
      */
     public function AddStitchVideoItem($url) {
         $item = new StitchVideoItem();
-        if ($this->stitchVideoItems == undefined) {
+        if (!isset($this->stitchVideoItems)) {
             $this->stitchVideoItems = [];
         }
         $item->url = $url;


### PR DESCRIPTION
Updated the AddStitchVideoItem to not check explicitly for undefined but instead use the isset() method. Newer versions of PHP will throw the following error when checking for undefined.

ErrorException: Use of undefined constant undefined - assumed 'undefined' (this will throw an Error in a future version of PHP)